### PR TITLE
chore(flake/nixpkgs): `b6eaf97c` -> `a84ebe20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`a6706df9`](https://github.com/NixOS/nixpkgs/commit/a6706df9c1e03469d8eba49b85e894a2969a5ce9) | `` python312Packages.pytorch-lightning: 2.5.0.post0 -> 2.5.1 ``                                    |
| [`bde2c002`](https://github.com/NixOS/nixpkgs/commit/bde2c0027ea474bbd286a81b31f90d96fabf5d85) | `` netbird: unbreak `netbird-ui` build  (#390989) ``                                               |
| [`b77b7e06`](https://github.com/NixOS/nixpkgs/commit/b77b7e06caba788a1cc5e00755ff8f2d573b8110) | `` fake-gcs-server: disable checks ``                                                              |
| [`3a48773f`](https://github.com/NixOS/nixpkgs/commit/3a48773f8c8a0b296ed815c8cc999339f5d49e5d) | `` bitbox-bridge: init at 1.6.1 ``                                                                 |
| [`e20d371d`](https://github.com/NixOS/nixpkgs/commit/e20d371d932e3d023bc94e3d45503949abd8260b) | `` maintainers: add izelnakri ``                                                                   |
| [`7106b623`](https://github.com/NixOS/nixpkgs/commit/7106b623945e327c7b2275b98bbc50d4d74cb89c) | `` postgresqlJitPackages.timescaledb: fix build ``                                                 |
| [`9d473f48`](https://github.com/NixOS/nixpkgs/commit/9d473f480f034c36fde8fa5974a4e6181705aef7) | `` postfix: re-add no-warnings patch ``                                                            |
| [`29386670`](https://github.com/NixOS/nixpkgs/commit/293866706b9a78d712aa447958cdf830775d53f5) | `` postgresqlPackages.timescaledb: 2.18.2 -> 2.19.0 ``                                             |
| [`990b3e32`](https://github.com/NixOS/nixpkgs/commit/990b3e32ec7e626207b2ed1d9c097885df890fbc) | `` pkgs/README: fix typo ``                                                                        |
| [`16e43b85`](https://github.com/NixOS/nixpkgs/commit/16e43b85940c821bbf0ab2fb7c491697884b62af) | `` vscode-extensions.rooveterinaryinc.roo-cline: 3.8.6 -> 3.9.2 ``                                 |
| [`b9586158`](https://github.com/NixOS/nixpkgs/commit/b958615808bcec0c08d9d16666ccb83979c04fb6) | `` _1password-gui: 8.10.60 -> 8.10.68 ``                                                           |
| [`75db2912`](https://github.com/NixOS/nixpkgs/commit/75db2912324f6909b2f6bca6e5416ffc01bfceb1) | `` _1password-gui: Do the PGP verification with an emphemeral GNUPGHOME ``                         |
| [`44914137`](https://github.com/NixOS/nixpkgs/commit/44914137eb58892ca5b6ab4db2835e245bf89767) | `` _1password-gui: Allow Linux and Darwin versions to move separately ``                           |
| [`94e7e165`](https://github.com/NixOS/nixpkgs/commit/94e7e165dac546cbf63eaac013a1478839bc2c93) | `` countryfetch: init at 0.1.9 ``                                                                  |
| [`7ef1acc7`](https://github.com/NixOS/nixpkgs/commit/7ef1acc72dd16e5afeb2e4426219a29308a0e019) | `` bloop: 2.0.8 -> 2.0.9 ``                                                                        |
| [`5c28518c`](https://github.com/NixOS/nixpkgs/commit/5c28518c4b57636c60baa308d03a4835f214492f) | `` nixos/modules/image: fix error message ``                                                       |
| [`57111b83`](https://github.com/NixOS/nixpkgs/commit/57111b831d452a1ea501494b23bfbda3862466ad) | `` uv: 0.6.6 -> 0.6.8 ``                                                                           |
| [`ef19fcf7`](https://github.com/NixOS/nixpkgs/commit/ef19fcf725eb3aa97289a91e3eb76e1c41a5a13f) | `` nixos/zipline: improve systemd hardening ``                                                     |
| [`0deb1b28`](https://github.com/NixOS/nixpkgs/commit/0deb1b285f9ebf5b51e74041b65a5f0fef0b0e82) | `` nixos/tests/zipline: add interactive config ``                                                  |
| [`3210c8b7`](https://github.com/NixOS/nixpkgs/commit/3210c8b7fa5310fe829a4064a1f4bb4d03047614) | `` penpot-desktop: 0.10.0 -> 0.11.0 ``                                                             |
| [`6509831a`](https://github.com/NixOS/nixpkgs/commit/6509831a8861818b9b304bc2f16fe2e8aa5c012c) | `` rke2_1_31: 1.31.5+rke2r1 -> 1.31.6+rke2r1 (#386837) ``                                          |
| [`7eaf5d7c`](https://github.com/NixOS/nixpkgs/commit/7eaf5d7cdf2b30d763fe0954ea4a79eb32ae4be4) | `` add a newline with each switch ``                                                               |
| [`57de201c`](https://github.com/NixOS/nixpkgs/commit/57de201c4396a54092f01dffe47de0e6f7d2db03) | `` warp-terminal: 0.2025.03.05.08.02.stable_02 -> 0.2025.03.12.08.02.stable_03 ``                  |
| [`697d082d`](https://github.com/NixOS/nixpkgs/commit/697d082d8e0b6da3839003f0982479b271491420) | `` youtrack: 2025.1.62967 -> 2025.1.66652 ``                                                       |
| [`9f97e8ca`](https://github.com/NixOS/nixpkgs/commit/9f97e8ca1df316c57c7498e6a1cd09544e94d208) | `` xpra: add a few missing dependencies ``                                                         |
| [`6eeb76d0`](https://github.com/NixOS/nixpkgs/commit/6eeb76d07a2d647355f3b1f9ffc981e485be01b1) | `` xpra: 6.2.3 -> 6.2.5 ``                                                                         |
| [`f19b9ebc`](https://github.com/NixOS/nixpkgs/commit/f19b9ebccbeafd17cff3efd8951afb34e481c2df) | `` crosvm: 0-unstable-2025-02-18 -> 0-unstable-2025-03-14 ``                                       |
| [`2f038e83`](https://github.com/NixOS/nixpkgs/commit/2f038e83933bf2abafd1a1c084337ce054afe10e) | `` civo: 1.1.97 -> 1.1.98 ``                                                                       |
| [`dad880d6`](https://github.com/NixOS/nixpkgs/commit/dad880d6bf01319b3b0dabb05e89c2a46b7365f3) | `` nixos/systemd: conditionally leave out some upstream units ``                                   |
| [`561f1f7a`](https://github.com/NixOS/nixpkgs/commit/561f1f7a6ea59a905598c8d1706787690825ec70) | `` systemd: expose withTpm2Units ``                                                                |
| [`ed0e5aaf`](https://github.com/NixOS/nixpkgs/commit/ed0e5aaf84cdd910bb0164ddcc045506be122f18) | `` broot: 1.44.7 -> 1.45.0 ``                                                                      |
| [`62be2042`](https://github.com/NixOS/nixpkgs/commit/62be2042b93e7eefbe56263dd3d5567884c60b6e) | `` maintainers/team-list: add GZGavinZhao & LunNova to rocm team, remove Madouura ``               |
| [`49509ee6`](https://github.com/NixOS/nixpkgs/commit/49509ee6874d5b9ff361690f4719c3e1249f3506) | `` crocoddyl: 2.2.0 -> 3.0.0 ``                                                                    |
| [`7c76d3b2`](https://github.com/NixOS/nixpkgs/commit/7c76d3b20bce2e75a95e3e8d403a0779d9a3f053) | `` openvmm: 0-unstable-2024-10-19 -> 0-unstable-2025-03-13 ``                                      |
| [`06adae40`](https://github.com/NixOS/nixpkgs/commit/06adae40983d14bbd20dccec6d8d0f34ad0c6af5) | `` llvmPackages_git: 2025-03-09 -> 2025-03-16 ``                                                   |
| [`a2569861`](https://github.com/NixOS/nixpkgs/commit/a256986143c55840ef99021ed584c151cfed1b6f) | `` diffoci: 0.1.5 -> 0.1.6 ``                                                                      |
| [`f7c51dd3`](https://github.com/NixOS/nixpkgs/commit/f7c51dd390a24f318947e64d7b003be740187db9) | `` sbt-extras: 2024-11-06 -> 2025-03-08 (#390852) ``                                               |
| [`759aed67`](https://github.com/NixOS/nixpkgs/commit/759aed67039d380ae3b15a79f0ba133ba847ed4e) | `` mani: refactor and add self as maintainer ``                                                    |
| [`a0fdba40`](https://github.com/NixOS/nixpkgs/commit/a0fdba4084f26057cf314ee533535d3f735c9836) | `` cook-cli: 0.7.1 -> 0.10.0 ``                                                                    |
| [`03097b07`](https://github.com/NixOS/nixpkgs/commit/03097b07f3dc007d2f308bf86cab61d0932dabb3) | `` forgejo-lts: 7.0.13 -> 7.0.14 ``                                                                |
| [`422c7912`](https://github.com/NixOS/nixpkgs/commit/422c7912b2cdcdd79ad796b3d42e50deca9aba33) | `` owntracks-recorder: 0.9.9 -> 1.0.0 ``                                                           |
| [`f375a86f`](https://github.com/NixOS/nixpkgs/commit/f375a86fc17993d15a44280c85e0e17bd0005377) | `` nixos/mautrix-telegram: switch to using static user for automated registration of appservice `` |
| [`59d80351`](https://github.com/NixOS/nixpkgs/commit/59d8035105aae8ace64e0840ca4ca42e27b0b87b) | `` dbvisualizer: 24.3.3 -> 25.1 ``                                                                 |
| [`8ca7560e`](https://github.com/NixOS/nixpkgs/commit/8ca7560e0c9e9f9dfd49425e8702b9f317814910) | `` hcl2json: 0.6.5 -> 0.6.6 ``                                                                     |
| [`629ed6c5`](https://github.com/NixOS/nixpkgs/commit/629ed6c53701b816219d732bf2d191c4599be4da) | `` zsh-autocomplete: 24.09.04 -> 25.03.19 ``                                                       |
| [`ca8f618d`](https://github.com/NixOS/nixpkgs/commit/ca8f618ddcd0bb03e0fdd86214f5013279088b8d) | `` fish: fix aarch64-linux test failures ``                                                        |
| [`afd525ff`](https://github.com/NixOS/nixpkgs/commit/afd525ff831b16cd70fe6d5707bc59edea52cfe4) | `` rattler-build: 0.38.0 -> 0.39.0 ``                                                              |
| [`ca06613e`](https://github.com/NixOS/nixpkgs/commit/ca06613ea7e4a5d7cf6ea5328727ece93e4780b5) | `` druid: 31.0.0 -> 32.0.0 ``                                                                      |
| [`4fb37a77`](https://github.com/NixOS/nixpkgs/commit/4fb37a77de44c358de664affda2fc9d26d3e1b0b) | `` cudaPackages.tensorrt: 10.8.0.43 -> 10.9.0.34 ``                                                |
| [`227f3049`](https://github.com/NixOS/nixpkgs/commit/227f30491e2251def35800d54b8a582c987d7392) | `` python3Packages.tensorrt: fix build for versions with missing build number ``                   |
| [`cfc2d23f`](https://github.com/NixOS/nixpkgs/commit/cfc2d23f7e3f270cbe50838b5376c4c31f80c4d2) | `` weblate: 5.10.3 -> 5.10.4 ``                                                                    |
| [`2f5bd7c8`](https://github.com/NixOS/nixpkgs/commit/2f5bd7c8c274e6736eda5bca501f23bedab75b63) | `` druid: fix broken symlink ``                                                                    |
| [`e100ca91`](https://github.com/NixOS/nixpkgs/commit/e100ca9133b61b5bc2f87956d97f743ecd482356) | `` python312Packages.duckduckgo-search: 7.2.1->7.5.2 ``                                            |
| [`de2de640`](https://github.com/NixOS/nixpkgs/commit/de2de64012b2e6f40ccbf2b2d0537707a1566177) | `` python312Packages.primp: 0.12.0->0.14.0 ``                                                      |
| [`520fe037`](https://github.com/NixOS/nixpkgs/commit/520fe037c8f5783a4b449abe51820cb3bac51cd0) | `` plasma-panel-colorizer: 2.3.0 -> 2.4.1 ``                                                       |
| [`2271c42f`](https://github.com/NixOS/nixpkgs/commit/2271c42fb8f5746538c1c2d05c39b74675b7a989) | `` home-assistant-custom-lovelace-modules.advanced-camera-card: 7.3.5 -> 7.3.6 (#391173) ``        |
| [`ecb95bc6`](https://github.com/NixOS/nixpkgs/commit/ecb95bc697b31a4f2cc1852a7c5ec2fa2c04fc58) | `` musescore: 4.4.4 -> 4.5 ``                                                                      |
| [`ef2bde5a`](https://github.com/NixOS/nixpkgs/commit/ef2bde5a13a0964b80d8cf0def8e7d478869dad5) | `` docker: use serviceConfig.ExecStart instead of script ``                                        |
| [`ccdfb91b`](https://github.com/NixOS/nixpkgs/commit/ccdfb91b4824eb17384ad4323abf33e462909aaa) | `` podman: use serviceConfig.ExecStart instead of script ``                                        |
| [`a819c8aa`](https://github.com/NixOS/nixpkgs/commit/a819c8aa5ddabdc9e2895da463ee850e50a328c7) | `` pythonPackages.wxpython: drop SDL dependency ``                                                 |
| [`58085b54`](https://github.com/NixOS/nixpkgs/commit/58085b540c76608783d19448eb1a061c64e814c9) | `` valgrind: don't use FreeBSD kernel version, use libc version ``                                 |
| [`ecf91e81`](https://github.com/NixOS/nixpkgs/commit/ecf91e819dd12855d02de7954833f52336b90da4) | `` spider: 2.33.11 -> 2.34.2 ``                                                                    |
| [`deb045e0`](https://github.com/NixOS/nixpkgs/commit/deb045e05755918cdf77f6ecb9da96cba9e7dbef) | `` initrd: implement panic-on-fail interpreterless ``                                              |
| [`19683d2d`](https://github.com/NixOS/nixpkgs/commit/19683d2d616bd615ffd3e28514e432db21b024cf) | `` paretosecurity: 0.0.86 -> 0.0.87 ``                                                             |
| [`333b660b`](https://github.com/NixOS/nixpkgs/commit/333b660b7a2c8dad11f83138012fc49f41e33f81) | `` ticker: 4.8.0 -> 4.8.1 ``                                                                       |
| [`b3c987c4`](https://github.com/NixOS/nixpkgs/commit/b3c987c4f424d2e8c7c2b29c04a104e7376b66e6) | `` vlc: drop dependency on SDL ``                                                                  |
| [`7f061752`](https://github.com/NixOS/nixpkgs/commit/7f06175244d388a34b633d09d8b3ba6b2b3cd5ef) | `` rucola: 0.4.1 -> 0.5.0 ``                                                                       |
| [`59a2fb6f`](https://github.com/NixOS/nixpkgs/commit/59a2fb6fbe6df699aeb24d1ad3523b0fc030a91d) | `` snowflake: 2.10.1 -> 2.11.0 ``                                                                  |
| [`dbda7296`](https://github.com/NixOS/nixpkgs/commit/dbda729619056853e785bce17181ba6c6af94ae1) | `` vimPlugins.indent-tools-nvim: init at 2023-10-28 ``                                             |
| [`d6dbb066`](https://github.com/NixOS/nixpkgs/commit/d6dbb0669c958cfb82e4e2741d804b395dc54595) | `` vimPlugins.arshlib-nvim: init at 2024-05-18 ``                                                  |
| [`14b42e61`](https://github.com/NixOS/nixpkgs/commit/14b42e61424bcd9a288ff4df2a0e894570f7393b) | `` python3Packages.nglview: init at 3.1.4 ``                                                       |
| [`b7c2674b`](https://github.com/NixOS/nixpkgs/commit/b7c2674b3c5bb0ab7585ee1149574d795176b2ad) | `` maintainers: add guelakais ``                                                                   |
| [`344cd371`](https://github.com/NixOS/nixpkgs/commit/344cd371e11f61bcf278c51e7eef016b59995b5c) | `` pmtiles: 1.25.3 -> 1.26.0 ``                                                                    |
| [`0d0e0994`](https://github.com/NixOS/nixpkgs/commit/0d0e0994e5c280011913a35616c04005db64cc4c) | `` railway: 3.22.0 -> 3.23.0 ``                                                                    |
| [`60d98a51`](https://github.com/NixOS/nixpkgs/commit/60d98a51638fef1419a0df7a5e2728925dc32d28) | `` z3_4_14: init at 4.14.1 ``                                                                      |
| [`d4f44c2b`](https://github.com/NixOS/nixpkgs/commit/d4f44c2bba2805efba31c93c43bc9c6d0d1acd76) | `` nushell: 0.102.0 -> 0.103.0 ``                                                                  |
| [`138c94cd`](https://github.com/NixOS/nixpkgs/commit/138c94cdb534ed7876bc0866444958ae5911bc51) | `` copywrite: 0.21.0 -> 0.22.0 ``                                                                  |
| [`5e8defe2`](https://github.com/NixOS/nixpkgs/commit/5e8defe22b9fd0982d8b46cad9ca2a5ae99fba89) | `` samrewritten: 202008-unstable-2025-01-09 -> 202008-unstable-2025-03-11 ``                       |
| [`c1934a44`](https://github.com/NixOS/nixpkgs/commit/c1934a44da229453a9b36abe3b80136bb5df430e) | `` ddns-go: 6.9.0 -> 6.9.1 ``                                                                      |
| [`3aadb410`](https://github.com/NixOS/nixpkgs/commit/3aadb410fbd2f5af891a462f0fabe9f5073fd3d9) | `` updatecli: 0.94.1 -> 0.95.1 ``                                                                  |