### PR TITLE
chore(flake/nixpkgs): `a84ebe20` -> `1e5b653d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742422364,
-        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`530f58ee`](https://github.com/NixOS/nixpkgs/commit/530f58eeb3410c95e2265b6d107bba32c351b70d) | `` Revert "ecryptfs: add test to release-combined.nix" ``                           |
| [`6c57ac8b`](https://github.com/NixOS/nixpkgs/commit/6c57ac8b3090d7022bd5ac1a072f297bdbdd6311) | `` webkitgtk_6_0: 2.46.6 → 2.48.0 ``                                                |
| [`d2d4d08c`](https://github.com/NixOS/nixpkgs/commit/d2d4d08c9f158f846864de7321bc21edec147061) | `` python313Packages.pyaprilaire: 0.8.0 -> 0.8.1 ``                                 |
| [`f4cc31f9`](https://github.com/NixOS/nixpkgs/commit/f4cc31f9586b46d314136baa727624e821d72a93) | `` python312Packages.nvdlib: 0.7.9 -> 0.8.0 ``                                      |
| [`bdd840c6`](https://github.com/NixOS/nixpkgs/commit/bdd840c6038fe543eb7070940145c8dd4c34fb73) | `` maintainers: update email for drawbu ``                                          |
| [`39ffda06`](https://github.com/NixOS/nixpkgs/commit/39ffda068bd0dd2626718f744e0a8cfbbb0e6a50) | `` python312Packages.llama-index-embeddings-google: 0.3.0 -> 0.3.1 ``               |
| [`3b5793de`](https://github.com/NixOS/nixpkgs/commit/3b5793deb59ca416dd097644244f1914f54b54c0) | `` miktex: init at 25.2 ``                                                          |
| [`c1fd35de`](https://github.com/NixOS/nixpkgs/commit/c1fd35de5438459401327e98d80be0b78ac83275) | `` nimlangserver: 1.8.1 -> 1.10.0 ``                                                |
| [`cf628879`](https://github.com/NixOS/nixpkgs/commit/cf628879d33438a27c8955d8e32b138a657f5820) | `` cifs-utils: 7.2 -> 7.3 ``                                                        |
| [`13e09835`](https://github.com/NixOS/nixpkgs/commit/13e098354424567e2c7838dcb5cf5d68794b8713) | `` python312Packages.types-pytz: 2025.1.0.20250204 -> 2025.1.0.20250318 ``          |
| [`38cf6436`](https://github.com/NixOS/nixpkgs/commit/38cf6436b399e961999c1a559109b696e1f0bb91) | `` libreoffice-still: 24.8.4.2 -> 24.8.5.2 ``                                       |
| [`11864397`](https://github.com/NixOS/nixpkgs/commit/1186439759756dd659e3d0e4a3bc342a0ec3169c) | `` stown: init at 1.2.0 ``                                                          |
| [`b332a419`](https://github.com/NixOS/nixpkgs/commit/b332a41989dacb68a60956242af1de0705966cdb) | `` balena-cli: 20.2.10 -> 21.1.0 ``                                                 |
| [`55d1a6db`](https://github.com/NixOS/nixpkgs/commit/55d1a6db69ca85a13073a3295b990ef7c3df43ae) | `` cloudfoundry-cli: 8.10.2 -> 8.11.0 ``                                            |
| [`b1850d36`](https://github.com/NixOS/nixpkgs/commit/b1850d3658016192b4ba1d806f7cc99ffbe9d456) | `` home-assistant-custom-components.midea_ac: 2025.2.3 -> 2025.3.0 ``               |
| [`9b696526`](https://github.com/NixOS/nixpkgs/commit/9b696526073a33674c2d22455cd7c5f7ef65d08c) | `` eresi: unbreak for gcc14 and newer ``                                            |
| [`a63ee8db`](https://github.com/NixOS/nixpkgs/commit/a63ee8db347528a6180c686cb5624d21e0bb3ae0) | `` python313Packages.msmart-ng: 2025.2.2 -> 2025.3.1 ``                             |
| [`0fec4a99`](https://github.com/NixOS/nixpkgs/commit/0fec4a999bcb7c3dfbb06f7a6a8c70222ad7fb10) | `` argocd: 2.14.4 -> 2.14.7 ``                                                      |
| [`7efdf405`](https://github.com/NixOS/nixpkgs/commit/7efdf40544a68fe254865bd81e6309f44a7f0a8c) | `` meme-suite: add homepage ``                                                      |
| [`564a67bb`](https://github.com/NixOS/nixpkgs/commit/564a67bb518bc6d8f50a14e84a1c3f3834c51ab0) | `` lyrebird: update homepage ``                                                     |
| [`8137c100`](https://github.com/NixOS/nixpkgs/commit/8137c100ad1e4bf2295db2181f1bbd6bd63cb927) | `` libreoffice-*: nixfmt the default.nix to avoid CI issues ``                      |
| [`8d54d26e`](https://github.com/NixOS/nixpkgs/commit/8d54d26eefa828b7747f46adca9eb7055c62d7fa) | `` ldm: add homepage ``                                                             |
| [`3fdf9433`](https://github.com/NixOS/nixpkgs/commit/3fdf94339eb336ee15514d7705bad470a42ea7e6) | `` icl: add homepage ``                                                             |
| [`89dd281d`](https://github.com/NixOS/nixpkgs/commit/89dd281d51c94c71f5824148f9df22176b021106) | `` knightos-kcc: update homepage ``                                                 |
| [`c574656a`](https://github.com/NixOS/nixpkgs/commit/c574656a431c517a29b6c8f860816233cad4cc2c) | `` kcc: update homepage ``                                                          |
| [`c218d49a`](https://github.com/NixOS/nixpkgs/commit/c218d49a221809a5b01f89023a59bd51c1c07d3e) | `` jot: update homepahe ``                                                          |
| [`f8656a45`](https://github.com/NixOS/nixpkgs/commit/f8656a45c5332048481d649e657513ae0685a69b) | `` helm: update homepage ``                                                         |
| [`013913f3`](https://github.com/NixOS/nixpkgs/commit/013913f3efc48c45d1d1aa4d634f0446b88b2cc1) | `` grip: update homepage ``                                                         |
| [`413ddcc1`](https://github.com/NixOS/nixpkgs/commit/413ddcc18ed55c1d2b3d8d081ef7d962888eb910) | `` gle: add homepage ``                                                             |
| [`0aad3a6f`](https://github.com/NixOS/nixpkgs/commit/0aad3a6f2bfeb51a901b4d3a64147543bb8d2a2b) | `` steamguard-cli: 0.16.0 -> 0.17.0 ``                                              |
| [`8d5548bb`](https://github.com/NixOS/nixpkgs/commit/8d5548bba35ec4023cab0f159a7575037ee19cdc) | `` blackbox: add homepage ``                                                        |
| [`479120b2`](https://github.com/NixOS/nixpkgs/commit/479120b2ed20b46f8a82b991c8a25e171e7c2d62) | `` python312Packages.types-markdown: 3.7.0.20241204 -> 3.7.0.20250322 ``            |
| [`f9eb7ff5`](https://github.com/NixOS/nixpkgs/commit/f9eb7ff5fe84fc8054a77856752cf01791287119) | `` asdf: add homepage ``                                                            |
| [`bc6061d0`](https://github.com/NixOS/nixpkgs/commit/bc6061d07c8cac63d92c2f98f0be990014984707) | `` ape: add homepage ``                                                             |
| [`ac70a338`](https://github.com/NixOS/nixpkgs/commit/ac70a33845a93ed97b9c379354fe43d784908846) | `` allure: update homepage ``                                                       |
| [`7aca5f35`](https://github.com/NixOS/nixpkgs/commit/7aca5f357e2daff0ec2d1bb650497586270286eb) | `` halo: 2.20.16 -> 2.20.17 ``                                                      |
| [`2bdec176`](https://github.com/NixOS/nixpkgs/commit/2bdec1760fc42ae84d34079a56ab676487492f97) | `` vals: 0.39.2 -> 0.39.4 ``                                                        |
| [`38a8ee37`](https://github.com/NixOS/nixpkgs/commit/38a8ee3702f559cc237aa310897c8a30eb076456) | `` cargo-shear: 1.1.9 -> 1.1.11 ``                                                  |
| [`f15b4331`](https://github.com/NixOS/nixpkgs/commit/f15b43314a6bfd8386a9ea53f6282e60947a4ad6) | `` kafkactl: 5.5.1 -> 5.6.0 ``                                                      |
| [`1b3214ef`](https://github.com/NixOS/nixpkgs/commit/1b3214ef7bead9746146356f552700e0320b587c) | `` python312Packages.persim: 0.3.7 -> 0.3.8 ``                                      |
| [`94f47451`](https://github.com/NixOS/nixpkgs/commit/94f474518426191bd4de29763804eafde0371094) | `` ctlptl: 0.8.39 -> 0.8.40 ``                                                      |
| [`f451b610`](https://github.com/NixOS/nixpkgs/commit/f451b610d6fb35cc5b4221b1f09b1542ca8fa4a6) | `` python312Packages.cli-helpers: 2.3.1 -> 2.4.0 ``                                 |
| [`0fb1bac9`](https://github.com/NixOS/nixpkgs/commit/0fb1bac9acbaa52dcec6450815926bc615d8dfc8) | `` python312Packages.pecan: refactor ``                                             |
| [`db06e570`](https://github.com/NixOS/nixpkgs/commit/db06e5704838550b4413ebb93c504cef282f70c5) | `` python313Packages.slack-sdk: 3.34.0 -> 3.35.0 ``                                 |
| [`118294c4`](https://github.com/NixOS/nixpkgs/commit/118294c49b9edb6325e2c2caf696e6f988efc8c3) | `` python313Packages.twilio: 9.5.0 -> 9.5.1 ``                                      |
| [`5000109c`](https://github.com/NixOS/nixpkgs/commit/5000109c2ddd65667e2811db6b617f2331668c23) | `` python313Packages.annotatedyaml: init at 0.4.4 ``                                |
| [`165b79ff`](https://github.com/NixOS/nixpkgs/commit/165b79ff3cd59c96ef4be459562128b92d3385d2) | `` python312Packages.types-retry: 0.9.9.20241221 -> 0.9.9.20250322 ``               |
| [`b56cea4d`](https://github.com/NixOS/nixpkgs/commit/b56cea4dcee80f94b432a3de472da7fcb77ddec0) | `` python312Packages.translate-toolkit: add changelog ``                            |
| [`d0f32962`](https://github.com/NixOS/nixpkgs/commit/d0f329628446a532a54a0ed29d0e9470b4811dbf) | `` postgresql: drop tests on aarch64-darwin, too ``                                 |
| [`4a560c73`](https://github.com/NixOS/nixpkgs/commit/4a560c731e92c8dac6ac3aa6e54dbd77bee860f4) | `` yt-dlp: 2025.2.19 -> 2025.3.21 ``                                                |
| [`47fbcc8f`](https://github.com/NixOS/nixpkgs/commit/47fbcc8feabc12e2aedbcb5d70bee3b383dfd4ea) | `` roxctl: 4.6.3 -> 4.7.0 ``                                                        |
| [`e827b11b`](https://github.com/NixOS/nixpkgs/commit/e827b11b93451eb713d73eae64d3b5e5283e441b) | `` cargo-about: 0.6.6 -> 0.7.1 ``                                                   |
| [`32037406`](https://github.com/NixOS/nixpkgs/commit/3203740681b5bd7617437f3c517ae7a36eaf354d) | `` copilot-language-server: 1.280.0 -> 1.290.0 ``                                   |
| [`46da653f`](https://github.com/NixOS/nixpkgs/commit/46da653f8de7e947a73a8c1ab9423e227b31fefa) | `` deltachat-desktop: 1.54.2 -> 1.56.0 ``                                           |
| [`c7df2503`](https://github.com/NixOS/nixpkgs/commit/c7df250395318e46d04efc83d4527254e564db8f) | `` cargo-spellcheck: 0.15.2 -> 0.15.5 ``                                            |
| [`80a35d65`](https://github.com/NixOS/nixpkgs/commit/80a35d65e4e46ddef40e8bf52301f77f8023a1fe) | `` apko: 0.25.2 -> 0.25.5 ``                                                        |
| [`c7ff8cc0`](https://github.com/NixOS/nixpkgs/commit/c7ff8cc0e1224fc1175c81b2b9855eef1bbda04e) | `` gurk-rs: 0.6.2 -> 0.6.3 ``                                                       |
| [`26557be0`](https://github.com/NixOS/nixpkgs/commit/26557be05a82ac62bc5a32ea33c81ddd845d349d) | `` python312Packages.llama-cloud: 0.1.14 -> 0.1.16 ``                               |
| [`46abc97d`](https://github.com/NixOS/nixpkgs/commit/46abc97d88aacc354bb68eabb43a51066db424cf) | `` python312Packages.essentials-openapi: 1.1.0 -> 1.1.1 ``                          |
| [`705d58f7`](https://github.com/NixOS/nixpkgs/commit/705d58f778cc25a776451affa055bd2bbf462637) | `` python312Packages.pecan: 1.5.1 -> 1.6.0 ``                                       |
| [`3b513fab`](https://github.com/NixOS/nixpkgs/commit/3b513fabaf8fe18380783f7265aa447b5d2fa6d4) | `` python312Packages.translate-toolkit: 3.15.0 -> 3.15.1 ``                         |
| [`2752f75d`](https://github.com/NixOS/nixpkgs/commit/2752f75d67fc7f7021540b6b611871b522944000) | `` chromium,chromedriver: 134.0.6998.117 -> 134.0.6998.165 ``                       |
| [`91c40e3a`](https://github.com/NixOS/nixpkgs/commit/91c40e3a44a2bd018453615ec3ec85626769e715) | `` python312Packages.tensorflow: remove unnecessary dependency patching ``          |
| [`270bf266`](https://github.com/NixOS/nixpkgs/commit/270bf2663a94d4ee3ae15023a7980adc66f02f69) | `` jbigkit: fix postInstall hook (make it unconditionnal) ``                        |
| [`cc9e60b4`](https://github.com/NixOS/nixpkgs/commit/cc9e60b4a99fa2742f4c04c3ee1ae7680cc62567) | `` lunacy: 11.0 -> 11.1 ``                                                          |
| [`69ee6f70`](https://github.com/NixOS/nixpkgs/commit/69ee6f700c6d5a0d90e1af705cb7eaddda92f6bd) | `` python312Packages.tensorflow: cleanup dependencies ``                            |
| [`b314d01a`](https://github.com/NixOS/nixpkgs/commit/b314d01ad1c7138f3c499608cacb8b443059dec9) | `` python312Packages.tensorflow: re-order inputs ``                                 |
| [`d50064f4`](https://github.com/NixOS/nixpkgs/commit/d50064f4e5895f14ca179c93eb98a1c4744b511d) | `` buildpack: 0.36.4 -> 0.37.0 ``                                                   |
| [`4e6065f9`](https://github.com/NixOS/nixpkgs/commit/4e6065f903e2e8a5ac25e1315dd663e2e03fa2be) | `` rustypaste: 0.16.0 -> 0.16.1 ``                                                  |
| [`967503f0`](https://github.com/NixOS/nixpkgs/commit/967503f0b27296ae35cd3bfbd102d0505afdf590) | `` roadrunner: 2024.3.3 -> 2024.3.5 ``                                              |
| [`ee713e84`](https://github.com/NixOS/nixpkgs/commit/ee713e84122c3a84f48cebcbe87b4ab7565e8081) | `` xdg-desktop-portal-gtk: 1.15.2 -> 1.15.3 ``                                      |
| [`4d17eb3c`](https://github.com/NixOS/nixpkgs/commit/4d17eb3cd3ae3431ca2e5f83c5285fc5eb745c12) | `` libwacom: 2.14.0 -> 2.15.0 ``                                                    |
| [`897b3630`](https://github.com/NixOS/nixpkgs/commit/897b36300252607def579bd8f8bf4a10f4a1bf96) | `` home-assistant: 2025.3.3 -> 2025.4.4 ``                                          |
| [`b56ca0ba`](https://github.com/NixOS/nixpkgs/commit/b56ca0ba583eab2fffc1c1cec5f925625a026f27) | `` python313Packages.zha: 0.0.52 -> 0.0.53 ``                                       |
| [`6fc12971`](https://github.com/NixOS/nixpkgs/commit/6fc12971c082cec6fc5691b507e5945e83298304) | `` python313Packages.python-snoo: 0.6.3 -> 0.6.4 ``                                 |
| [`e14f01dd`](https://github.com/NixOS/nixpkgs/commit/e14f01ddf1e96ccf8457dd68b9f0faf5f40a433c) | `` python313Packages.pylamarzocco: 1.4.7 -> 1.4.9 ``                                |
| [`02e05259`](https://github.com/NixOS/nixpkgs/commit/02e05259540c5717d69c581cd296428006e18d2e) | `` python312Packages.reflex-hosting-cli: 0.1.35 -> 0.1.36 ``                        |
| [`9bc0333e`](https://github.com/NixOS/nixpkgs/commit/9bc0333ed5695b21a0ab1c6ded961615e187d2d4) | `` python312Packages.smolagents: disable test that requires missing dep `mlx-lm` `` |
| [`0605dc61`](https://github.com/NixOS/nixpkgs/commit/0605dc61aff51cb356640d333871bacaff458b90) | `` highs: 1.9.0 -> 1.10.0 ``                                                        |
| [`28e0f02f`](https://github.com/NixOS/nixpkgs/commit/28e0f02f53e017a576c7e05b7c34406a7894dc79) | `` cargo-update: 16.2.0 -> 16.2.1 ``                                                |
| [`f9863dea`](https://github.com/NixOS/nixpkgs/commit/f9863deaec83ec414f7dfe2d4bf1f5e0e05e3630) | `` python312Packages.pyytlounge: 2.2.1 -> 2.3.0 ``                                  |
| [`7e69ba35`](https://github.com/NixOS/nixpkgs/commit/7e69ba35c22e5caf03b694867ca4cfa84b200dee) | `` python3Packages.llama-cpp-python: 0.3.6 -> 0.3.8 ``                              |
| [`ff345e3e`](https://github.com/NixOS/nixpkgs/commit/ff345e3e058343965b5dfb7b2eba6c94a485d8ec) | `` python312Packages.azure-ai-vision-imageanalysis: fix meta attributes ``          |
| [`184fa3e0`](https://github.com/NixOS/nixpkgs/commit/184fa3e038e611e3169fed6a43fc454f8b22bb9f) | `` hatch: fix build on darwin ``                                                    |
| [`be52d9e8`](https://github.com/NixOS/nixpkgs/commit/be52d9e8c5fbecb4f0bfd4570682067bb8c650b5) | `` evcc: 0.201.0 -> 0.201.1 ``                                                      |
| [`9b45dcfa`](https://github.com/NixOS/nixpkgs/commit/9b45dcfae4f61b20e0e2c1505373af3fef12f777) | `` home-assistant-custom-components.lednetwf_ble: init at 0.0.14.2 ``               |
| [`1e9604dc`](https://github.com/NixOS/nixpkgs/commit/1e9604dcc5f6d877b9b7ee490ce3a6ba7ae268e0) | `` python312Packages.qpsolvers: add jaxopt ``                                       |
| [`92e6a2dc`](https://github.com/NixOS/nixpkgs/commit/92e6a2dc38a7fe84e5660d0d102531c2eb9d201f) | `` python312Packages.prometheus-fastapi-instrumentator: 7.0.2 -> 7.1.0 ``           |
| [`12717c31`](https://github.com/NixOS/nixpkgs/commit/12717c310b345c2ab96ca8b2eb0da3fdfda664df) | `` komac: 2.11.0 -> 2.11.1 ``                                                       |
| [`ead39fa3`](https://github.com/NixOS/nixpkgs/commit/ead39fa32847ba0623b9a32bdc33c4b347ba055d) | `` esphome: 2025.2.2 -> 2025.3.0 ``                                                 |
| [`47dbba16`](https://github.com/NixOS/nixpkgs/commit/47dbba169d49d3cc435c52bbafbc8ca44157c274) | `` inputplumber: 0.49.2 -> 0.49.6 ``                                                |
| [`c531fff5`](https://github.com/NixOS/nixpkgs/commit/c531fff5cb0c9f81bcb3c408202baf01ba49f84d) | `` gotosocial: 0.18.2 -> 0.18.3 ``                                                  |
| [`4d50cf24`](https://github.com/NixOS/nixpkgs/commit/4d50cf24f2649f2000dc5a6616cbf8f15b8ea09c) | `` legcord: add nyabinary as maintainer ``                                          |
| [`32270bad`](https://github.com/NixOS/nixpkgs/commit/32270bad8340e7bd645249118ea81cad36e13b2b) | `` legcord: refactor ``                                                             |
| [`ef29ebf8`](https://github.com/NixOS/nixpkgs/commit/ef29ebf891e39cf1ecb91fc304cee856f0b8c974) | `` legcord: 1.1.0 -> 1.1.1 ``                                                       |