### PR TITLE
chore(flake/nixpkgs): `8fcc7145` -> `dda3dcd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746592047,
-        "narHash": "sha256-GYYT5Pc+sZZWomgC7EgDSNSfmXd9Jby9nXQ6bAswUCg=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8fcc71459655f2486b3da197b8d6a62f595a33d2",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`205cb960`](https://github.com/NixOS/nixpkgs/commit/205cb9602bee6697edf6402c1555b323a846613e) | `` odin: dev-2025-01 -> dev-2025-04 ``                                            |
| [`7cd4f789`](https://github.com/NixOS/nixpkgs/commit/7cd4f7897f44edb5686ab0820bf5cf8b666df360) | `` python312Packages.wandb: skip failing test on darwin ``                        |
| [`a386622c`](https://github.com/NixOS/nixpkgs/commit/a386622c94990024546ceec5eff6448ad8a6c0d5) | `` xan: 0.49.3 -> 0.50.0 ``                                                       |
| [`51a98307`](https://github.com/NixOS/nixpkgs/commit/51a9830754c59eb53a3cffbcf9e588db5dbc1b4c) | `` pysdl2: exclude failing tests ``                                               |
| [`a45cba95`](https://github.com/NixOS/nixpkgs/commit/a45cba95978c3fd4df507a4fd1da93b52e9fe62c) | `` pkgsite: 0-unstable-2025-04-24 -> 0-unstable-2025-05-06 ``                     |
| [`14e70b59`](https://github.com/NixOS/nixpkgs/commit/14e70b59218155f93b2df33906083d87cb3bb374) | `` python3Packages.coqpit: 0.1.2 -> 0.2.0 ``                                      |
| [`13de4b2b`](https://github.com/NixOS/nixpkgs/commit/13de4b2b669eb5480b15988375a28b9f176cf37b) | `` vacuum-go: 0.16.6 -> 0.16.8 ``                                                 |
| [`e3456013`](https://github.com/NixOS/nixpkgs/commit/e3456013d015124238a1b444bdb2dc84661b26d1) | `` python313Packages.django_5: 5.1.8 -> 5.1.9 ``                                  |
| [`60c0d9a6`](https://github.com/NixOS/nixpkgs/commit/60c0d9a6438f34f1e7f49fae9cf31b7e2b177eba) | `` ungoogled-chromium: 136.0.7103.59-1 -> 136.0.7103.92-1 ``                      |
| [`ca69ed4b`](https://github.com/NixOS/nixpkgs/commit/ca69ed4bc6e2cdf282eabda0cd665738d65821bc) | `` terraform-providers.btp: 1.11.0 -> 1.12.0 ``                                   |
| [`5fe815c9`](https://github.com/NixOS/nixpkgs/commit/5fe815c93ee1bf0df8e96922c4ded30e68582e51) | `` python3Packages.webdataset: disable tests that hang on Darwin ``               |
| [`7c8de812`](https://github.com/NixOS/nixpkgs/commit/7c8de8123bf4c9bd887e6e40b15112933e9e2f7e) | `` intentrace: 0.9.5 -> 0.9.7 ``                                                  |
| [`dd7cec7c`](https://github.com/NixOS/nixpkgs/commit/dd7cec7ce4f0ccad8a47cdd46dbfa0fcc8522e1c) | `` uv: 0.7.2 -> 0.7.3 ``                                                          |
| [`f5c6c167`](https://github.com/NixOS/nixpkgs/commit/f5c6c167f1c278acba071a03309ffc3782e7759f) | `` cudaPackages.autoAddCudaCompatRunpath: badPlatforms broken ``                  |
| [`41e370ec`](https://github.com/NixOS/nixpkgs/commit/41e370ecfbb0edec763458212a59cbf30a9dde23) | `` lumail: drop ``                                                                |
| [`2fb4be99`](https://github.com/NixOS/nixpkgs/commit/2fb4be99f358507c8ee496ecf99fbb147357d464) | `` python3Packages.frigidaire: 0.18.23 -> 0.18.24 ``                              |
| [`5c28ddb1`](https://github.com/NixOS/nixpkgs/commit/5c28ddb1e5db6e5be108e6e4751b0803a96ffe96) | `` jai: init at 0.2.010 ``                                                        |
| [`f3569bc1`](https://github.com/NixOS/nixpkgs/commit/f3569bc16e9c85d75766450572bc9dcaa1531c35) | `` surrealdb: 2.3.0 -> 2.3.1 ``                                                   |
| [`aa8b531b`](https://github.com/NixOS/nixpkgs/commit/aa8b531b90743a37ea0ab5558ba941251f5e149d) | `` flyctl: 0.3.110 -> 0.3.116 ``                                                  |
| [`78a7b8d6`](https://github.com/NixOS/nixpkgs/commit/78a7b8d69306795d9c0eb3d84259ffc14cd63097) | `` typstyle: 0.13.4 -> 0.13.5 ``                                                  |
| [`47c82b0c`](https://github.com/NixOS/nixpkgs/commit/47c82b0cf53c12c190b5c9badfd7554e82e6ddc0) | `` vscode-extensions.vadimcn.vscode-lldb: various adjustments following review `` |
| [`d8b50484`](https://github.com/NixOS/nixpkgs/commit/d8b50484d3724f0891c3fda1c738f103ae132d33) | `` vscode-extensions.vadimcn.vscode-lldb: 1.10.0 -> 1.11.4 ``                     |
| [`a7f22e88`](https://github.com/NixOS/nixpkgs/commit/a7f22e88264985d703ef4a187c1c8cd8e7fbf3ee) | `` vscode-extensions.vadimcn.vscode-lldb: Fix update.sh ``                        |
| [`d7ea3c4f`](https://github.com/NixOS/nixpkgs/commit/d7ea3c4fd4ce10341bad331339628d75732cbc77) | `` postgresql_17: 17.4 -> 17.5 ``                                                 |
| [`6de66bc0`](https://github.com/NixOS/nixpkgs/commit/6de66bc0be67ec82b9102c223f3dc85201236dfb) | `` postgresql_16: 16.8 -> 16.9 ``                                                 |
| [`4003ab65`](https://github.com/NixOS/nixpkgs/commit/4003ab6564b7e2c4480c018308a012b59b4a9c2e) | `` postgresql_15: 15.12 -> 15.13 ``                                               |
| [`43873fd4`](https://github.com/NixOS/nixpkgs/commit/43873fd4aac2dec9749486e5a05de7ece195d711) | `` postgresql_14: 14.17 -> 14.18 ``                                               |
| [`02f2714c`](https://github.com/NixOS/nixpkgs/commit/02f2714c55d44b9fb949386811b123407f9da963) | `` workflows/no-channel: fix typo ``                                              |
| [`0552a5b5`](https://github.com/NixOS/nixpkgs/commit/0552a5b5a99c18a350e0149528a5f35e78eeca76) | `` postgresql_13: 13.20 -> 13.21 ``                                               |
| [`a70d047c`](https://github.com/NixOS/nixpkgs/commit/a70d047c15924eb72388dd35b2826e34c3f69872) | `` workflows/editorconfig.editorconfig-checker: 2.4.0 -> 3.2.0 ``                 |
| [`5d145166`](https://github.com/NixOS/nixpkgs/commit/5d14516619b4356bbffb95b5f31a59462fe9a6ad) | `` various: remove trailing whitespace ``                                         |
| [`f2a9d17b`](https://github.com/NixOS/nixpkgs/commit/f2a9d17b7a4e1941750d24b50ac6c08a10e3e3ef) | `` xbindkeys-config: add .editorconfig for generated file ``                      |
| [`c8d2eca9`](https://github.com/NixOS/nixpkgs/commit/c8d2eca963370b84f8a5cbc8e11628f1f0602876) | `` .editorconfig: move subfolder config into separate .editorconfig files ``      |
| [`0245105e`](https://github.com/NixOS/nixpkgs/commit/0245105e541d86179775f8d5d07bb144dfda435a) | `` .editorconfig: fix moved folders ``                                            |
| [`1131a6cd`](https://github.com/NixOS/nixpkgs/commit/1131a6cd5b2d1985a4c72e7faf0490d094f08bf2) | `` ammonite: 3.0.0-M1 -> 3.0.2 ``                                                 |
| [`b5cc0da7`](https://github.com/NixOS/nixpkgs/commit/b5cc0da768d2e95da5d9ba9bacdeb3f83ec9b4d9) | `` python3Packages.pybind11-protobuf: unbreak ``                                  |
| [`8df7737b`](https://github.com/NixOS/nixpkgs/commit/8df7737bbfbcf191811bb4357aed49962b10582d) | `` bloop: 2.0.9 -> 2.0.10 ``                                                      |
| [`0766c3d8`](https://github.com/NixOS/nixpkgs/commit/0766c3d82f04ba4aab95d4f6e33ade9f29ceccf5) | `` await: fix homepage url ``                                                     |
| [`cd355600`](https://github.com/NixOS/nixpkgs/commit/cd355600100b3fceb9baa6447efecf6c96a0aa88) | `` nim-2_2: remove left-over, unused, darwin.Security ``                          |
| [`cd92df70`](https://github.com/NixOS/nixpkgs/commit/cd92df7002e76d5657d6c5800ebe285482f616a0) | `` ltwheelconf: drop ``                                                           |
| [`bed71f27`](https://github.com/NixOS/nixpkgs/commit/bed71f2713d935e2d07ae1759d01e2ece7b5cddc) | `` stubby: fix eval by removing darwin.Security ``                                |
| [`1767ea14`](https://github.com/NixOS/nixpkgs/commit/1767ea143e5c20943a21c093b1e4b7fca76b4755) | `` ibus-engines.table: 1.17.11 -> 1.17.12 ``                                      |
| [`2326019a`](https://github.com/NixOS/nixpkgs/commit/2326019ab430b023910d31708959d9d91237651f) | `` xdg-desktop-portal: don't reference unused umockdev ``                         |
| [`2cbda4c1`](https://github.com/NixOS/nixpkgs/commit/2cbda4c13be061f105dea96bdccc74dfd987c217) | `` stubby: add enableStubOnly (ENABLE_STUB_ONLY) option ``                        |
| [`a34d5697`](https://github.com/NixOS/nixpkgs/commit/a34d5697f8eb08fc4c799692ffa28089bbb39c08) | `` getdns/stubby: move to pkgs/by-name ``                                         |
| [`04210b80`](https://github.com/NixOS/nixpkgs/commit/04210b8085c335317c16ad42f18a10f4fce34a01) | `` mongodb-atlas-cli: 1.42.1 -> 1.42.2 ``                                         |
| [`4f64ebd0`](https://github.com/NixOS/nixpkgs/commit/4f64ebd02b0cf1623bf4bf13a27a7a2d1b186b2e) | `` ci/eval-stats: sort output table by metric name ``                             |
| [`c8276114`](https://github.com/NixOS/nixpkgs/commit/c8276114ac18237c8fcf5a2e416578aab58eb393) | `` fix(ci/eval-stats): resolve prResult symlink ``                                |
| [`c50cc4db`](https://github.com/NixOS/nixpkgs/commit/c50cc4dbc5d094dbdbd835605560af9784f2dbbd) | `` gotosocial: 0.19.0 -> 0.19.1 ``                                                |
| [`cc97f27d`](https://github.com/NixOS/nixpkgs/commit/cc97f27d66cb8c2a7a43611a6b19dc3f01123fc3) | `` penpot-desktop: 0.13.0 -> 0.13.1 ``                                            |
| [`ca94a9e3`](https://github.com/NixOS/nixpkgs/commit/ca94a9e3913c1d95074bd6ad5af64905b76e8378) | `` python312Packages.gradio: 5.20.0 -> 5.29.0 ``                                  |
| [`c2f83f83`](https://github.com/NixOS/nixpkgs/commit/c2f83f831d9f7263a8b3f8d2b1b72ad58745dd50) | `` python312Packages.gradio-client: 1.7.2 -> 1.10.0 ``                            |
| [`e7fcda1e`](https://github.com/NixOS/nixpkgs/commit/e7fcda1e172879ef5420ec38d01fe30f75827e0b) | `` terraform-providers.talos: 0.7.1 -> 0.8.0 ``                                   |
| [`25be8c1a`](https://github.com/NixOS/nixpkgs/commit/25be8c1a4f6e25ebc16bac7ed2b88e64e7770c15) | `` lomiri.lomiri-telephony-service: 0.6.0 -> 0.6.1 ``                             |
| [`578f23a3`](https://github.com/NixOS/nixpkgs/commit/578f23a3b0d6a86cdb9372149f294fbf2a7da5cf) | `` emscripten: 3.1.73 -> 4.0.8 ``                                                 |
| [`e2a3d8a6`](https://github.com/NixOS/nixpkgs/commit/e2a3d8a65702687941929096840c903e2e0ed82d) | `` binaryen: 120_b -> 123; ``                                                     |
| [`34ee4fb3`](https://github.com/NixOS/nixpkgs/commit/34ee4fb353979d433960fb9d0459820001555e88) | `` firecracker: 1.11.0 -> 1.12.0 ``                                               |
| [`18690c27`](https://github.com/NixOS/nixpkgs/commit/18690c27d7f80fb8d915b9e11bdea10c6c812b3f) | `` lprobe: 0.1.5 -> 0.1.6 ``                                                      |
| [`91ed0b2c`](https://github.com/NixOS/nixpkgs/commit/91ed0b2c85518bcc60879787d76615eadf379543) | `` bingo: use finalAttrs ``                                                       |
| [`e7a9ba71`](https://github.com/NixOS/nixpkgs/commit/e7a9ba7112257ecbebe58d4da0d7a70d5ea6f5a9) | `` givaro_3: drop ``                                                              |
| [`5c462f5e`](https://github.com/NixOS/nixpkgs/commit/5c462f5e08c58f22fa30528b31de863ab544846d) | `` givaro_3_7: drop ``                                                            |
| [`d4565460`](https://github.com/NixOS/nixpkgs/commit/d456546008ba87c601d2135580bf8388b2e75a43) | `` okteto: 3.6.0 -> 3.7.0 ``                                                      |
| [`ebfd190e`](https://github.com/NixOS/nixpkgs/commit/ebfd190e9f8b5b3252adfd7526bf31030806c997) | `` gerrit: 3.11.2 -> 3.11.3 ``                                                    |
| [`d71e6d40`](https://github.com/NixOS/nixpkgs/commit/d71e6d40b1ee72573296cf5145355729c6e3b00b) | `` powerstat: 0.04.04 -> 0.04.05 ``                                               |
| [`01539dbc`](https://github.com/NixOS/nixpkgs/commit/01539dbc26c05b2cd30e9a9ce369526bc297b77b) | `` safety-cli: 3.4.0 -> 3.5.0 ``                                                  |
| [`50960c1f`](https://github.com/NixOS/nixpkgs/commit/50960c1fbdaed09a1c4c9a93847e65c4ca5660d1) | `` hyprpaper: 0.7.4 -> 0.7.5 ``                                                   |
| [`b7a2f556`](https://github.com/NixOS/nixpkgs/commit/b7a2f556e92d83043653febae20d1ccae6b85d9c) | `` python312Packages.docling-serve: 0.8.0 -> 0.10.1 ``                            |
| [`44c66ee9`](https://github.com/NixOS/nixpkgs/commit/44c66ee92de591900a2de4969d51a8b5b1a85696) | `` libfive: 0-unstable-2024-10-10 -> 0-unstable-2025-05-04 ``                     |
| [`66fbe09a`](https://github.com/NixOS/nixpkgs/commit/66fbe09a1883a8a0d82379212c4ef9484ec5a5af) | `` kubevpn: 2.7.2 -> 2.7.5 ``                                                     |
| [`5f152068`](https://github.com/NixOS/nixpkgs/commit/5f15206805586bf3346b0f606f3106470655951e) | `` vimPlugins.luau-lsp-nvim: add luau-lsp to runtimeDeps ``                       |
| [`3ac12307`](https://github.com/NixOS/nixpkgs/commit/3ac12307ee2210ae3af7fcfbe2c5a3e438703ae0) | `` luau-lsp: init at 1.45.0 ``                                                    |
| [`ebea925f`](https://github.com/NixOS/nixpkgs/commit/ebea925f77608d8843b94cde0a3130d635f95b7b) | `` hawknl: drop ``                                                                |
| [`d5e59c70`](https://github.com/NixOS/nixpkgs/commit/d5e59c70c04afb67a079ff6189b1fd996d7af42e) | `` python3Packages.recipe-scrapers: 15.6.0 -> 15.7.1 ``                           |
| [`db9d1d52`](https://github.com/NixOS/nixpkgs/commit/db9d1d52676461447b33edb2a925cf0c9036305a) | `` python3Packages.linuxpy: 0.20.0 -> 0.21.0 ``                                   |
| [`4436504c`](https://github.com/NixOS/nixpkgs/commit/4436504c1c711fb2cfc2a94c3610563c69ff4061) | `` vscode-extensions.saoudrizwan.claude-dev: 3.13.3 -> 3.14.0 ``                  |
| [`4c8b59b6`](https://github.com/NixOS/nixpkgs/commit/4c8b59b663d8f0ebf9a736c0f93fd16d731f275d) | `` dbeaver-bin: 25.0.2 -> 25.0.4 ``                                               |
| [`18f15620`](https://github.com/NixOS/nixpkgs/commit/18f15620ce03212c7254161c80a37acb5e43aed4) | `` python3Packages.langchain: revert bad update (#404770) ``                      |
| [`65833bab`](https://github.com/NixOS/nixpkgs/commit/65833bab78442dc5d563d24d422162e956679fa3) | `` kdePackages: Plasma 6.3.4 -> 6.3.5 ``                                          |
| [`1a87d461`](https://github.com/NixOS/nixpkgs/commit/1a87d4612eeabe036fb35722419967b75e7a1d65) | `` hcp: 0.9.0 -> 0.9.1 ``                                                         |
| [`b8ca313e`](https://github.com/NixOS/nixpkgs/commit/b8ca313e970eb1a07c905c50c91206db5afde718) | `` labels: prevent labelling PRs to staging-next as backport ``                   |
| [`4865391b`](https://github.com/NixOS/nixpkgs/commit/4865391bdf6557d7340951c9cb5d3aca359f306b) | `` mumps-mpi: renamed from package mumps_par ``                                   |
| [`6a6c5ef7`](https://github.com/NixOS/nixpkgs/commit/6a6c5ef7a49e7509691175feaa8b45845c549942) | `` svtplay-dl: 4.103 -> 4.109 ``                                                  |
| [`b7812015`](https://github.com/NixOS/nixpkgs/commit/b7812015f97fc4999375b28145882c56ce10bbc6) | `` portfolio: 0.76.0 -> 0.76.1 ``                                                 |
| [`fb0f5e5f`](https://github.com/NixOS/nixpkgs/commit/fb0f5e5f7617c63e07f84bc282e5f662bf52e2e0) | `` prometheus-squid-exporter: 1.12.0 -> 1.13.0 ``                                 |
| [`bb0ca527`](https://github.com/NixOS/nixpkgs/commit/bb0ca5271d23d94a0caea9e998c9d035ad0d8b3a) | `` Add `noNakedPointer` option to the ocaml package (#404668) ``                  |
| [`b6ddf8ed`](https://github.com/NixOS/nixpkgs/commit/b6ddf8ed57a821fd797c81e39658e188d6bf502e) | `` vimPlugins.famous-quotes-nvim: init at 2025-05-07 ``                           |
| [`3faf2060`](https://github.com/NixOS/nixpkgs/commit/3faf2060a3bcc45a769af2864d945140463a1a36) | `` retroarch-joypad-autoconfig: 1.20.0 -> 1.21.1 ``                               |
| [`d7c7fb64`](https://github.com/NixOS/nixpkgs/commit/d7c7fb6480240b4352106b41d11e8d2f964d47c2) | `` python312Packages.coiled: update license ``                                    |
| [`7681dbb5`](https://github.com/NixOS/nixpkgs/commit/7681dbb5c1d9ac21155447916cd40a4596f3c332) | `` python313Packages.img2pdf: 0.6.0 -> 0.6.1 (#404633) ``                         |
| [`86415e18`](https://github.com/NixOS/nixpkgs/commit/86415e18136b7757ab69545e72971632bff20613) | `` dbeaver-bin: improve update script ``                                          |
| [`ec307e3e`](https://github.com/NixOS/nixpkgs/commit/ec307e3e4e43d454055f4344c6acb9ee3a327134) | `` nu_scripts: 0-unstable-2025-04-23 -> 0-unstable-2025-05-05 ``                  |
| [`5b8e0bda`](https://github.com/NixOS/nixpkgs/commit/5b8e0bdaebad18212ae023169a26482620956ead) | `` beancount-share: 2023-12-31 -> 0.1.11 ``                                       |
| [`1c991fd9`](https://github.com/NixOS/nixpkgs/commit/1c991fd9080277ca1a45b09e04f1facbdc40508b) | `` beancount-ing-diba: 0.6.0 -> 1.1.0 ``                                          |
| [`f1e09360`](https://github.com/NixOS/nixpkgs/commit/f1e093601814ea31f14ba546f12c34fa39ba03a8) | `` snpguest: 0.8.3 -> 0.9.1 ``                                                    |
| [`222b02ef`](https://github.com/NixOS/nixpkgs/commit/222b02efef349280f08913c364a0c7bb930a8292) | `` camilladsp: init at 3.0.1 ``                                                   |
| [`79073050`](https://github.com/NixOS/nixpkgs/commit/7907305002de26918273929b8781584c24a10a69) | `` rosa: 1.2.52 -> 1.2.53 ``                                                      |